### PR TITLE
chore(android): update for Android 12

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -17,7 +17,7 @@ jobs:
     env:
       CCACHE_DIR: ${{ github.workspace }}/.ccache
       USE_CCACHE: 1
-      SDK_VERSION: 9.3.2.GA
+      SDK_VERSION: 10.1.0.v20210820083427
       MODULE_ID: appcelerator.bluetooth
     steps:
     - uses: actions/checkout@v2
@@ -26,6 +26,12 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: '12.x'
+
+    - name: Use JDK 11
+      uses: actions/setup-java@v2
+      with:
+        distribution: 'adopt'
+        java-version: '11'
 
     - name: Cache Node.js modules
       id: node-cache

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 library 'pipeline-library'
 
 buildModule {
-	sdkVersion = '9.3.1.GA'
+	sdkVersion = '10.1.0.v20210820083427'
 	npmPublish = false // By default it'll do github release on master anyways too
 	androidAPILevel = '30' // unit-tests of bluetooth module are executable on emulator with api level 30.
 	androidBuildToolsVersion = '30.0.2'

--- a/README.md
+++ b/README.md
@@ -15,20 +15,6 @@ The bluetooth variable is a reference to the Module object.
 
 ## Getting Started
 
-- Edit the `manifest` with following `uses-permission` element to the Android manifest section of the
-  tiapp.xml file.
-  ``` xml
-  <ti:app>
-    <android xmlns:android="http://schemas.android.com/apk/res/android">
-      <manifest>
-        <uses-permission android:name="android.permission.BLUETOOTH" />
-        <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
-        <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/> 
-      </manifest>
-    </android>
-  </ti:app>
-  ```
-
 - Set the ``` <module> ``` element in tiapp.xml, such as this: 
   ``` xml
   <modules>

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 1.0.1
+version: 2.0.0
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: Titanium Bluetooth module for Android
@@ -15,4 +15,4 @@ name: Bluetooth
 moduleid: appcelerator.bluetooth
 guid: d4c8bc3c-dce5-48b4-9c7e-5ccb5102f205
 platform: android
-minsdk: 9.0.0.GA
+minsdk: 10.0.0.GA

--- a/android/src/appcelerator/bluetooth/BluetoothModule.java
+++ b/android/src/appcelerator/bluetooth/BluetoothModule.java
@@ -9,27 +9,34 @@ import android.Manifest;
 import android.app.Activity;
 import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothDevice;
+import android.bluetooth.BluetoothManager;
+import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.pm.PackageManager;
+import android.os.Build;
 import android.util.Log;
-import androidx.core.app.ActivityCompat;
-import androidx.core.content.ContextCompat;
 import appcelerator.bluetooth.Receivers.DiscoveryBroadcastReceiver;
 import appcelerator.bluetooth.Receivers.StateBroadcastReceiver;
+import appcelerator.bluetooth.Receivers.UUIDBroadcastReceiver;
+import java.util.ArrayList;
 import java.util.Set;
 import org.appcelerator.kroll.KrollDict;
+import org.appcelerator.kroll.KrollFunction;
 import org.appcelerator.kroll.KrollModule;
+import org.appcelerator.kroll.KrollObject;
+import org.appcelerator.kroll.KrollPromise;
+import org.appcelerator.kroll.KrollRuntime;
 import org.appcelerator.kroll.annotations.Kroll;
-import org.appcelerator.kroll.common.TiConfig;
+import org.appcelerator.titanium.TiApplication;
+import org.appcelerator.titanium.TiBaseActivity;
+import org.appcelerator.titanium.TiC;
 
 @Kroll.module(name = "Bluetooth", id = "appcelerator.bluetooth")
 public class BluetoothModule extends KrollModule
 {
-
 	// Standard Debugging variables
 	private static final String LCAT = "BluetoothModule";
-	private static final boolean DBG = TiConfig.LOGD;
 	@Kroll.constant
 	public static final int DEVICE_TYPE_CLASSIC = BluetoothDevice.DEVICE_TYPE_CLASSIC;
 	@Kroll.constant
@@ -59,19 +66,39 @@ public class BluetoothModule extends KrollModule
 	private final String PAIRED_DEVICES_SUCCESS_KEY = "success";
 	private final String PAIRED_DEVICES_MESSAGE_KEY = "message";
 	private final String PAIRED_DEVICES_KEY = "pairedDevices";
-	private final BluetoothAdapter btAdapter;
+	private BluetoothAdapter btAdapter;
 	private StateBroadcastReceiver stateReceiver;
 	private DiscoveryBroadcastReceiver discoveryReceiver;
 
 	public BluetoothModule()
 	{
 		super();
-		btAdapter = BluetoothAdapter.getDefaultAdapter();
+
+		// Fetch bluetooth adapter.
+		final Context context = TiApplication.getInstance();
+		BluetoothManager bluetoothManager = (BluetoothManager) context.getSystemService(Context.BLUETOOTH_SERVICE);
+		if (bluetoothManager != null) {
+			this.btAdapter = bluetoothManager.getAdapter();
+		}
+
+		// Set up bluetooth broadcast receivers.
 		IntentFilter intentFilter = new IntentFilter();
 		intentFilter.addAction(BluetoothAdapter.ACTION_STATE_CHANGED);
-		stateReceiver = new StateBroadcastReceiver(this);
-		discoveryReceiver = new DiscoveryBroadcastReceiver(this);
-		getActivity().registerReceiver(stateReceiver, intentFilter);
+		this.discoveryReceiver = new DiscoveryBroadcastReceiver(this);
+		this.stateReceiver = new StateBroadcastReceiver(this);
+		context.registerReceiver(stateReceiver, intentFilter);
+
+		// Unregister broadcast receivers when the JS runtime is about to be terminated.
+		KrollRuntime.addOnDisposingListener(new KrollRuntime.OnDisposingListener() {
+			@Override
+			public void onDisposing(KrollRuntime runtime)
+			{
+				KrollRuntime.removeOnDisposingListener(this);
+				context.unregisterReceiver(stateReceiver);
+				DiscoveryBroadcastReceiver.unregisterAll();
+				UUIDBroadcastReceiver.unregisterAll();
+			}
+		});
 	}
 
 	@Override
@@ -119,25 +146,109 @@ public class BluetoothModule extends KrollModule
 	@Kroll.method
 	public boolean isRequiredPermissionsGranted()
 	{
-		return getActivity().getPackageManager().checkPermission(Manifest.permission.BLUETOOTH,
-																 getActivity().getPackageName())
-			== PackageManager.PERMISSION_GRANTED
-			&& getActivity().getPackageManager().checkPermission(Manifest.permission.BLUETOOTH_ADMIN,
-																 getActivity().getPackageName())
-				   == PackageManager.PERMISSION_GRANTED
-			&& getActivity().getPackageManager().checkPermission(Manifest.permission.ACCESS_FINE_LOCATION,
-																 getActivity().getPackageName())
-				   == PackageManager.PERMISSION_GRANTED;
+		return isRequiredPermissionsGranted(false);
+	}
+
+	private boolean isRequiredPermissionsGranted(boolean isRequestingLocationOnly)
+	{
+		// Create the permission list.
+		ArrayList<String> permissionList = new ArrayList<>(4);
+		permissionList.add(Manifest.permission.ACCESS_FINE_LOCATION);
+		if (!isRequestingLocationOnly) {
+			if (Build.VERSION.SDK_INT >= 31) {
+				permissionList.add(Manifest.permission.BLUETOOTH_ADVERTISE);
+				permissionList.add(Manifest.permission.BLUETOOTH_CONNECT);
+				permissionList.add(Manifest.permission.BLUETOOTH_SCAN);
+			} else {
+				permissionList.add(Manifest.permission.BLUETOOTH);
+				permissionList.add(Manifest.permission.BLUETOOTH_ADMIN);
+			}
+		}
+
+		// Determine if permissions are granted.
+		// Note: On OS versions older than Android 6.0, check if permission is defined in manifest.
+		TiApplication context = TiApplication.getInstance();
+		PackageManager packageManager = context.getPackageManager();
+		String packageName = context.getPackageName();
+		for (String permissionName : permissionList) {
+			if (Build.VERSION.SDK_INT >= 23) {
+				if (context.checkSelfPermission(permissionName) != PackageManager.PERMISSION_GRANTED) {
+					return false;
+				}
+			} else if (packageManager.checkPermission(permissionName, packageName)
+					   != PackageManager.PERMISSION_GRANTED) {
+				return false;
+			}
+		}
+		return true;
 	}
 
 	@Kroll.method
-	public void requestAccessFinePermission()
+	public KrollPromise<KrollDict>
+	requestAccessFinePermission(@Kroll.argument(optional = true) KrollFunction permissionCallback)
 	{
-		if (ContextCompat.checkSelfPermission(getActivity(), Manifest.permission.ACCESS_FINE_LOCATION)
-			!= PackageManager.PERMISSION_GRANTED) {
-			ActivityCompat.requestPermissions(getActivity(), new String[] { Manifest.permission.ACCESS_FINE_LOCATION },
-											  1);
-		}
+		return requestPermissions(permissionCallback, true);
+	}
+
+	@Kroll.method
+	public KrollPromise<KrollDict> requestPermissions(@Kroll.argument(optional = true) KrollFunction permissionCallback)
+	{
+		return requestPermissions(permissionCallback, false);
+	}
+
+	private KrollPromise<KrollDict> requestPermissions(KrollFunction permissionCallback,
+													   boolean isRequestingLocationOnly)
+	{
+		final KrollObject krollObject = getKrollObject();
+		return KrollPromise.create((promise) -> {
+			// Do not continue if we already have permission.
+			if (isRequiredPermissionsGranted(isRequestingLocationOnly)) {
+				KrollDict responseData = new KrollDict();
+				responseData.putCodeAndMessage(0, null);
+				if (permissionCallback != null) {
+					permissionCallback.callAsync(krollObject, responseData);
+				}
+				promise.resolve(responseData);
+				return;
+			} else if (Build.VERSION.SDK_INT < 23) {
+				KrollDict responseData = new KrollDict();
+				responseData.putCodeAndMessage(-1, "Permission(s) not defined in manifest.");
+				if (permissionCallback != null) {
+					permissionCallback.callAsync(krollObject, responseData);
+				}
+				promise.reject(new Throwable(responseData.getString(TiC.EVENT_PROPERTY_ERROR)));
+				return;
+			}
+
+			// Do not continue if there is no activity to host the request dialog.
+			Activity activity = TiApplication.getInstance().getCurrentActivity();
+			if (activity == null) {
+				KrollDict responseData = new KrollDict();
+				responseData.putCodeAndMessage(-1, "There are no activities to host the permission request dialog.");
+				if (permissionCallback != null) {
+					permissionCallback.callAsync(krollObject, responseData);
+				}
+				promise.reject(new Throwable(responseData.getString(TiC.EVENT_PROPERTY_ERROR)));
+				return;
+			}
+
+			// Create the permission list.
+			ArrayList<String> permissionList = new ArrayList<>(4);
+			permissionList.add(Manifest.permission.ACCESS_FINE_LOCATION);
+			if (Build.VERSION.SDK_INT >= 31) {
+				permissionList.add(Manifest.permission.ACCESS_COARSE_LOCATION);
+				if (!isRequestingLocationOnly) {
+					permissionList.add(Manifest.permission.BLUETOOTH_ADVERTISE);
+					permissionList.add(Manifest.permission.BLUETOOTH_CONNECT);
+					permissionList.add(Manifest.permission.BLUETOOTH_SCAN);
+				}
+			}
+
+			// Show dialog requesting permission.
+			TiBaseActivity.registerPermissionRequestCallback(TiC.PERMISSION_CODE_LOCATION, permissionCallback,
+															 krollObject, promise);
+			activity.requestPermissions(permissionList.toArray(new String[0]), TiC.PERMISSION_CODE_LOCATION);
+		});
 	}
 
 	/**
@@ -231,16 +342,17 @@ public class BluetoothModule extends KrollModule
 			Log.e(LCAT, "Required permission not granted");
 			return false;
 		}
-		if (btAdapter.startDiscovery()) {
-			IntentFilter intentFilter = new IntentFilter();
-			intentFilter.addAction(BluetoothAdapter.ACTION_DISCOVERY_STARTED);
-			intentFilter.addAction(BluetoothAdapter.ACTION_DISCOVERY_FINISHED);
-			intentFilter.addAction(BluetoothDevice.ACTION_FOUND);
-			getActivity().registerReceiver(discoveryReceiver, intentFilter);
-			return true;
+		if (!btAdapter.startDiscovery()) {
+			Log.e(LCAT, "startDiscovery(): Could not start discovery due to the error. ");
+			return false;
 		}
-		Log.e(LCAT, "startDiscovery(): Could not start discovery due to the error. ");
-		return false;
+
+		IntentFilter intentFilter = new IntentFilter();
+		intentFilter.addAction(BluetoothAdapter.ACTION_DISCOVERY_STARTED);
+		intentFilter.addAction(BluetoothAdapter.ACTION_DISCOVERY_FINISHED);
+		intentFilter.addAction(BluetoothDevice.ACTION_FOUND);
+		TiApplication.getInstance().registerReceiver(this.discoveryReceiver, intentFilter);
+		return true;
 	}
 
 	@Kroll.method
@@ -312,16 +424,5 @@ public class BluetoothModule extends KrollModule
 		boolean isSecure = dict.optBoolean("secure", false);
 
 		return new BluetoothServerSocketProxy(name, uuid, isSecure);
-	}
-
-	@Override
-	public void onDestroy(Activity activity)
-	{
-		try {
-			getActivity().unregisterReceiver(stateReceiver);
-		} catch (IllegalArgumentException e) {
-			Log.w(LCAT, e.getMessage());
-		}
-		super.onDestroy(activity);
 	}
 }

--- a/android/src/appcelerator/bluetooth/BluetoothServerSocketProxy.java
+++ b/android/src/appcelerator/bluetooth/BluetoothServerSocketProxy.java
@@ -7,14 +7,17 @@ package appcelerator.bluetooth;
 
 import android.annotation.SuppressLint;
 import android.bluetooth.BluetoothAdapter;
+import android.bluetooth.BluetoothManager;
 import android.bluetooth.BluetoothServerSocket;
 import android.bluetooth.BluetoothSocket;
+import android.content.Context;
 import android.util.Log;
 import java.io.IOException;
 import java.util.UUID;
 import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.KrollProxy;
 import org.appcelerator.kroll.annotations.Kroll;
+import org.appcelerator.titanium.TiApplication;
 
 @Kroll.proxy
 @SuppressLint("LongLogTag")
@@ -45,9 +48,16 @@ public class BluetoothServerSocketProxy extends KrollProxy
 	@Kroll.method
 	public void startAccept(@Kroll.argument(optional = true) boolean keepListening)
 	{
-
 		if (state != ServerSocketState.Open) {
 			Log.d(TAG, "startAccept: unable to startAccept as current state = " + state);
+			return;
+		}
+
+		TiApplication context = TiApplication.getInstance();
+		BluetoothManager bluetoothManager = (BluetoothManager) context.getSystemService(Context.BLUETOOTH_SERVICE);
+		BluetoothAdapter bluetoothAdapter = (bluetoothManager != null) ? bluetoothManager.getAdapter() : null;
+		if (bluetoothAdapter == null) {
+			Log.e(TAG, "startAccept: bluetooth not supported on device.");
 			return;
 		}
 
@@ -55,11 +65,9 @@ public class BluetoothServerSocketProxy extends KrollProxy
 
 		try {
 			if (isSecure) {
-				serverSocket = BluetoothAdapter.getDefaultAdapter().listenUsingRfcommWithServiceRecord(
-					name, UUID.fromString(uuid));
+				serverSocket = bluetoothAdapter.listenUsingRfcommWithServiceRecord(name, UUID.fromString(uuid));
 			} else {
-				serverSocket = BluetoothAdapter.getDefaultAdapter().listenUsingInsecureRfcommWithServiceRecord(
-					name, UUID.fromString(uuid));
+				serverSocket = bluetoothAdapter.listenUsingInsecureRfcommWithServiceRecord(name, UUID.fromString(uuid));
 			}
 		} catch (IOException e) {
 			Log.e(TAG, "startAccept: unable to startAccept due to exception.", e);

--- a/android/src/appcelerator/bluetooth/Receivers/DiscoveryBroadcastReceiver.java
+++ b/android/src/appcelerator/bluetooth/Receivers/DiscoveryBroadcastReceiver.java
@@ -11,11 +11,14 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import appcelerator.bluetooth.BluetoothDeviceProxy;
+import java.util.ArrayList;
 import java.util.HashMap;
 import org.appcelerator.kroll.KrollModule;
+import org.appcelerator.titanium.TiApplication;
 
 public class DiscoveryBroadcastReceiver extends BroadcastReceiver
 {
+	private static final ArrayList<DiscoveryBroadcastReceiver> receiverList = new ArrayList<>(1);
 	private KrollModule krollModule;
 	private final String EVENT_DEVICE_FOUND = "deviceFound";
 	private final String EVENT_DEVICE_FOUND_KEY = "device";
@@ -26,6 +29,7 @@ public class DiscoveryBroadcastReceiver extends BroadcastReceiver
 	public DiscoveryBroadcastReceiver(KrollModule krollModule)
 	{
 		this.krollModule = krollModule;
+		receiverList.add(this);
 	}
 
 	@Override
@@ -48,7 +52,23 @@ public class DiscoveryBroadcastReceiver extends BroadcastReceiver
 			krollModule.fireEvent(EVENT_DISCOVERY_STARTED, "discovery is started");
 		} else if (BluetoothAdapter.ACTION_DISCOVERY_FINISHED.equals(action)) {
 			krollModule.fireEvent(EVENT_DISCOVERY_FINISHED, "discovery is finished");
-			krollModule.getActivity().unregisterReceiver(this);
+			unregister();
+		}
+	}
+
+	public void unregister()
+	{
+		try {
+			receiverList.remove(this);
+			TiApplication.getInstance().unregisterReceiver(this);
+		} catch (Exception ex) {
+		}
+	}
+
+	public static void unregisterAll()
+	{
+		while (!receiverList.isEmpty()) {
+			receiverList.get(0).unregister();
 		}
 	}
 }

--- a/android/timodule.xml
+++ b/android/timodule.xml
@@ -1,11 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ti:module xmlns:ti="http://ti.appcelerator.org" xmlns:android="http://schemas.android.com/apk/res/android">
-	<!--
-		Similar to tiapp.xml, but contains module/platform specific
-		configuration in <iphone> and <android> sections
-	-->
-	<iphone>
-	</iphone>
 	<android xmlns:android="http://schemas.android.com/apk/res/android">
+		<manifest>
+			<!-- Fine location permission needed for bluetooth device discovery. -->
+			<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+			<uses-permission android:name="android.permission.ACCESS_COURSE_LOCATION"/>
+
+			<!-- Bluetooth permission needed by Android 12 and higher. -->
+			<uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE"/>
+			<uses-permission android:name="android.permission.BLUETOOTH_CONNECT"/>
+			<uses-permission android:name="android.permission.BLUETOOTH_SCAN"/>
+
+			<!-- Legacy bluetooth permissions needed by Android 11 and older OS versions. -->
+			<!-- ACTION_REQUEST_DISCOVERABLE needs BLUETOOTH permission on Android 12 even though docs say otherwise. -->
+			<uses-permission android:name="android.permission.BLUETOOTH"/>
+			<uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30"/>
+		</manifest>
 	</android>
 </ti:module>

--- a/apidoc/Bluetooth.yml
+++ b/apidoc/Bluetooth.yml
@@ -26,19 +26,6 @@ description: |
       ``` javascript
       bluetooth.isSupported();
       ```
-    - Add the following `uses-permission` element to the Android manifest section of the tiapp.xml
-        file. You may need to add the `manifest elements.
-        ``` xml
-        <ti:app>
-            <android xmlns:android="http://schemas.android.com/apk/res/android">
-                <manifest>
-                    <uses-permission android:name="android.permission.BLUETOOTH" />
-                    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
-                    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/> 
-                </manifest>
-            </android>
-        </ti:app>
-        ```
 
     ### Example application
       Please see the /modules/android/appcelerator.bluetooth/x.y.z (version of module)/example folder.
@@ -355,9 +342,18 @@ methods:
   - name: isRequiredPermissionsGranted
     summary: Determines whether the required permissions are granted or not.
     description: |
-        The type of permissions included are, BLUETOOTH, BLUTOOTH_ADMIN and ACCESS_FINE_LOCATION.
-        ACCESS_FINE_LOCATION permission is provided at runtime by the app user. To request this permission
-        use [requestAccessFinePermission](Modules.Bluetooth.requestAccessFinePermission) method
+        Checks if the following permissions are defined and have been granted by the user:
+
+        * `android.permission.ACCESS_FINE_LOCATION`
+        * `android.permission.BLUETOOTH`
+        * `android.permission.BLUETOOTH_ADMIN`
+        * `android.permission.BLUETOOTH_ADVERTISE`
+        * `android.permission.BLUETOOTH_CONNECT`
+        * `android.permission.BLUETOOTH_SCAN`
+
+        If this method returns `false`, then you should call the
+        [requestPermissions](Modules.Bluetooth.requestPermissions) method to display a dialog
+        requesting permissions from the user.
     since: "1.0.0"
     platforms: [android]
     returns:
@@ -373,11 +369,44 @@ methods:
       summary: "Returns true if Bluetooth is supported on the device, false otherwise."
 
   - name: requestAccessFinePermission
-    summary: Request for the `ACCESS_FINE_LOCATION`. This permission is necessary for the Bluetooth device to scan the nearby devices.
+    summary: Displays a dialog requesting location permission from the user.
     description: |
-        If this permission is not requested, startDiscovery method will not be able to scan the
-        nearby devices. 
+        Displays a dialog requesting the user for the `ACCESS_FINE_LOCATION` permission.
+        This permission is required by the [startDiscovery](Modules.Bluetooth.startDiscovery) method.
+        The dialog will not be dispayed if permission has already been granted.
+
+        The given optional callback argument and returned `Promise` will provide a `success` property
+        indicating if permission was granted or not.
+    parameters:
+      - name: callback
+        summary: Function to be invoked indicating if permission was granted or not.
+        type: Callback<Titanium.Android.RequestPermissionAccessResult>
+        optional: true
+    returns:
+      summary: As of 2.0.0, this method will return a `Promise` whose resolved value is equivalent to that passed to the optional callback argument.
+      type: Promise<Titanium.Android.RequestPermissionAccessResult>
     since: "1.0.0"
+    platforms: [android]
+
+  - name: requestPermissions
+    summary: Displays a dialog requesting all permissions needed by the bluetooth module from the user.
+    description: |
+        Displays a dialog requesting the user for the `ACCESS_FINE_LOCATION` permission.
+        Will also request the `BLUETOOTH_ADVERTISE`, `BLUETOOTH_CONNECT`, and `BLUETOOTH_SCAN` permissions
+        if running on Android 12 or higher. These permission are required by this module to
+        discover devices and to make the app's device discoverable by other devices.
+
+        The given optional callback argument and returned `Promise` will provide a `success` property
+        indicating if permissions were granted or not.
+    parameters:
+      - name: callback
+        summary: Function to be invoked indicating if permissions were granted or not.
+        type: Callback<Titanium.Android.RequestPermissionAccessResult>
+        optional: true
+    returns:
+      summary: Returns a `Promise` whose resolved value is equivalent to that passed to the optional callback argument.
+      type: Promise<Titanium.Android.RequestPermissionAccessResult>
+    since: "2.0.0"
     platforms: [android]
 
   - name: setName

--- a/example/app.js
+++ b/example/app.js
@@ -125,16 +125,15 @@ var btRequestPermissionbutton = Ti.UI.createButton({
 });
 
 btRequestPermissionbutton.addEventListener('click', function () {
-	var requestPermissionToast = Ti.UI.createNotification({
-		duration: Ti.UI.NOTIFICATION_DURATION_LONG
+	bluetooth.requestPermissions((e) => {
+		let message = e.success ? 'Permission granted' : 'Permission denied';
+		const toast = Ti.UI.createNotification({
+			duration: Ti.UI.NOTIFICATION_DURATION_LONG,
+			message: message
+		});
+		toast.show();
+		Ti.API.info(message);
 	});
-	if (!bluetooth.isRequiredPermissionsGranted()) {
-		bluetooth.requestAccessFinePermission();
-	} else {
-		requestPermissionToast.message = 'Required Permission is already granted';
-		requestPermissionToast.show();
-		Ti.API.info('Required Permission is already granted');
-	}
 });
 
 bluetooth.addEventListener('stateChanged', function (e) {

--- a/example/image_transfer/image_receiver.js
+++ b/example/image_transfer/image_receiver.js
@@ -149,10 +149,10 @@ function deleteAndCreateNewImage() {
 	}
 	let imgFile = Ti.Filesystem.getFile(imageDir.resolve(), 'image.png');
 	if (imgFile.exists()) {
-		let deleteResult = imgFile.deleteFile();
+		imgFile.deleteFile();
 	}
 	if (!imgFile.exists()) {
-		let createResult = imgFile.createFile();
+		imgFile.createFile();
 	}
 	return imgFile;
 }

--- a/example/serversocket.js
+++ b/example/serversocket.js
@@ -111,7 +111,7 @@ function Server(btServerSocket) {
 			message: 'Bluetooth Socket Accepted.\nDevice Name = ' + btDeviceProxy.name + '\nDevice Address = ' + btDeviceProxy.address,
 			title: 'Connection Received'
 		});
-		dialog.addEventListener('click', function (b) {
+		dialog.addEventListener('click', function () {
 			var DataCommunication = require('data_communication.js'); // to use image transfer, make use of  'image_transfer/image_sender.js' file here.
 			new DataCommunication(socket).open();
 			win.close();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@titanium-sdk/appcelerator.bluetooth",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@titanium-sdk/appcelerator.bluetooth",
-      "version": "1.0.1",
+      "version": "2.0.0",
       "devDependencies": {
         "@commitlint/cli": "^12.1.1",
         "@commitlint/config-conventional": "^12.1.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "format:js": "npm run lint:js -- --fix",
     "lint": "npm run lint:android && npm run lint:js && npm run lint:docs",
     "lint:android": "clang-format-lint android/src/**/*.java",
-    "lint:docs": "tdoc-validate -w Titanium.Blob,Titanium.UI.View,Titanium.Proxy,Titanium.Module,Titanium.Buffer,Point apidoc",
+    "lint:docs": "tdoc-validate -w Titanium.Blob,Titanium.UI.View,Titanium.Proxy,Titanium.Module,Titanium.Buffer,Titanium.Android.RequestPermissionAccessResult,Point apidoc",
     "lint:js": "eslint .",
     "test": "npm run lint && npm run test:unit",
     "test:unit": "karma start test/unit/karma.unit.config.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titanium-sdk/appcelerator.bluetooth",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "private": true,
   "description": "Provides Bluetooth elements for Titanium applications",
   "scripts": {

--- a/test/unit/karma.unit.config.js
+++ b/test/unit/karma.unit.config.js
@@ -3,7 +3,7 @@
 module.exports = config => {
 	config.set({
 		basePath: '../..',
-		frameworks: [ 'jasmine', 'projectManagerHook' ],
+		frameworks: [ 'jasmine' ],
 		files: [
 			'test/unit/specs/bluetoothinit.spec.js',
 			'test/unit/specs/**/*spec.js'

--- a/test/unit/karma.unit.config.js
+++ b/test/unit/karma.unit.config.js
@@ -1,22 +1,5 @@
 'use strict';
 
-const path = require('path');
-const fs = require('fs-extra');
-
-function projectManagerHook(projectManager) {
-	projectManager.once('prepared', function () {
-		const tiapp = path.join(this.karmaRunnerProjectPath, 'tiapp.xml');
-		var contents = fs.readFileSync(tiapp, 'utf8');
-		contents = contents.replace('</android>', `<manifest>
-                                                   			<uses-permission android:name="android.permission.BLUETOOTH" />
-                                                   			<uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
-                                                   		</manifest>
-		</android>`);
-		fs.writeFileSync(tiapp, contents, 'utf8');
-	});
-}
-projectManagerHook.$inject = [ 'projectManager' ];
-
 module.exports = config => {
 	config.set({
 		basePath: '../..',
@@ -27,10 +10,7 @@ module.exports = config => {
 		],
 		reporters: [ 'mocha', 'junit' ],
 		plugins: [
-			'karma-*',
-			{
-				'framework:projectManagerHook': [ 'factory', projectManagerHook ]
-			}
+			'karma-*'
 		],
 		titanium: {
 			sdkVersion: config.sdkVersion || '9.3.1.GA'

--- a/test/unit/karma.unit.config.js
+++ b/test/unit/karma.unit.config.js
@@ -13,7 +13,7 @@ module.exports = config => {
 			'karma-*'
 		],
 		titanium: {
-			sdkVersion: config.sdkVersion || '9.3.1.GA'
+			sdkVersion: config.sdkVersion || '10.1.0.v20210820083427'
 		},
 		customLaunchers: {
 			android: {

--- a/test/unit/specs/bluetoothsocket.spec.js
+++ b/test/unit/specs/bluetoothsocket.spec.js
@@ -53,7 +53,7 @@ describe('BluetoothSocket ', function () {
 			});
 
 			it('attempting connect for a random uuid fires the error event', done => {
-				socket.on('error', e => {
+				socket.on('error', () => {
 					done();
 				});
 


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIMOB-28481

**Summary:**
- Set minsdk to Titanium 10.0.0. (Because I updated APIs to support promises.)
- Added `promise` and callback argument support to `requestAccessFineLocation()` API.
- Added new method `requestPermissions()` which requests user for bluetooth and location permissions.
- Fixed broadcast receivers to unregister themselves when backing out of the app.
  * Used to have a bug where old receivers were still bound to a terminated JS runtime.
- Added new Android 12 permissions:
  * [android.permission.BLUETOOTH_ADVERTISE](https://developer.android.com/reference/android/Manifest.permission#BLUETOOTH_ADVERTISE)
  * [android.permission.BLUETOOTH_CONNECT](https://developer.android.com/reference/android/Manifest.permission#BLUETOOTH_CONNECT)
  * [android.permission.BLUETOOTH_SCAN](https://developer.android.com/reference/android/Manifest.permission#BLUETOOTH_SCAN)
- Limited deprecated [android.permission.BLUETOOTH_ADMIN](https://developer.android.com/reference/android/Manifest.permission#BLUETOOTH_ADMIN) permission up to Android 11
- Note: Cannot limit deprecated [android.permission.BLUETOOTH](https://developer.android.com/reference/android/Manifest.permission#BLUETOOTH) permission to Android 11 because Android 12 still requires it for the [ACTION_REQUEST_DISCOVERABLE](https://developer.android.com/reference/android/bluetooth/BluetoothAdapter#ACTION_REQUEST_DISCOVERABLE) intent on Android 12, even though Google's docs say it's not needed. (Is this an issue with the current beta?)
